### PR TITLE
fix trailingComma setting description

### DIFF
--- a/package.json
+++ b/package.json
@@ -116,7 +116,7 @@
               "none",
               "all"
             ],
-            "description": "%scssFormatter.config.singleQuote.description%"
+            "description": "%scssFormatter.config.trailingComma.description%"
           }
         }
       }


### PR DESCRIPTION
`trailingComma` description was the same with `singleQuote` description