### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,6 +10,8 @@ env:
 jobs:
   test:
     name: Publish to Markeplace
+    permissions:
+      contents: read
     runs-on: macos-latest
 
     environment:


### PR DESCRIPTION
Potential fix for [https://github.com/sibiraj-s/vscode-scss-formatter/security/code-scanning/2](https://github.com/sibiraj-s/vscode-scss-formatter/security/code-scanning/2)

To fix the problem, add a `permissions` block to the workflow or to the specific job. The minimal starting point is `contents: read`, which grants the least privilege necessary for most workflows that only need to read repository contents. Since the job is named "Publish to Markeplace" and runs a deploy script, it may require more than just read access (e.g., `contents: write` if it pushes tags or releases), but the minimal fix per the CodeQL suggestion is to add `contents: read`. This should be added at the job level (under `test:`) or at the root of the workflow (top-level, before `jobs:`). For this fix, we'll add it at the job level for clarity and minimal impact.

**What to change:**  
- In `.github/workflows/publish.yml`, under the `test:` job (after line 12), add:
  ```yaml
    permissions:
      contents: read
  ```
No new imports or definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
