### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,3 +1,5 @@
+permissions:
+  contents: read
 name: Tests
 
 on:


### PR DESCRIPTION
Potential fix for [https://github.com/sibiraj-s/vscode-scss-formatter/security/code-scanning/1](https://github.com/sibiraj-s/vscode-scss-formatter/security/code-scanning/1)

To fix the problem, you should add a `permissions` block to the workflow to restrict the GITHUB_TOKEN permissions to the minimum required. Since the workflow only checks out code and runs tests, it does not require write access to any repository resources. The minimal permission required is `contents: read`, which allows the workflow to read repository contents but not modify them. This block can be added either at the root of the workflow (to apply to all jobs) or at the job level. The best practice is to add it at the root level, just below the `name` and before the `on` block, so that all jobs inherit these minimal permissions unless overridden.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
